### PR TITLE
Fix for bug in GL3LightingManager::endLightPass

### DIFF
--- a/src/renderer/opengl/GL3LightingManager.cpp
+++ b/src/renderer/opengl/GL3LightingManager.cpp
@@ -203,7 +203,7 @@ void GL3LightingManager::endLightPass() {
 
         _lightingPassProgram->bindAndSetParameters(&_lightingPassParameters);
         _quadVertexLayout->bind();
-        glDrawArrays(GL_TRIANGLES, 0, 6);
+        glDrawArrays(GL_TRIANGLES, 0, 3);
     }
 
     // Now copy the depth component back to the screen


### PR DESCRIPTION
Since we're only drawing one triangle, we need to adjust this call to avoid bad things
